### PR TITLE
make TAB configuration org-mode compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This package allows emacs to use [Racer](http://github.com/phildawes/racer) for 
    ```el
 
    (add-hook 'racer-mode-hook #'company-mode)
-
-   (global-set-key (kbd "TAB") #'company-indent-or-complete-common) ;
+   (add-hook 'company-mode-hook
+      (lambda () (local-set-key (kbd "TAB") #'company-indent-or-complete-common)))
    (setq company-tooltip-align-annotations t)
    ```
    For automatic completions, customize `company-idle-delay` and `company-minimum-prefix-length`.


### PR DESCRIPTION
For me, the sample code to set the TAB key to autocomplete given in the Readme,

```
(global-set-key (kbd "TAB") #'company-indent-or-complete-common) ;
```

caused problems with org-mode, where TAB wouldn't work any more to indent. I suggest to change the sample code to

```
(add-hook 'company-mode-hook
  (lambda () (local-set-key (kbd "TAB") #'company-indent-or-complete-common)))
```

to avoid these problems.
